### PR TITLE
Make XpressSolver struct mutable for Alpine compatibility.

### DIFF
--- a/src/XpressSolverInterface.jl
+++ b/src/XpressSolverInterface.jl
@@ -40,7 +40,7 @@ function copy(m::XpressMathProgModel)
                                 deepcopy(m.options))
 end
 
-struct XpressSolver <: AbstractMathProgSolver
+mutable struct XpressSolver <: AbstractMathProgSolver
     options
 end
 XpressSolver(;kwargs...) = XpressSolver(kwargs)


### PR DESCRIPTION
I''m working on support for Xpress as mip solver for Alpine, and this change seems to be necessary given the way Alpine sets the settings for the subsolvers. Any reason to keep it the way it is?