### PR TITLE
Add support and tests for semicontinuous and semi integer variables

### DIFF
--- a/src/MOI/MOI_wrapper.jl
+++ b/src/MOI/MOI_wrapper.jl
@@ -1100,6 +1100,17 @@ function _set_variable_lower_bound(model, info, value)
     # end
 end
 
+"""
+    _set_variable_semi_lower_bound(model, info, value)
+
+This function set the semi lower bound of a semi-continuous or semi-integer variable.
+The lower bound of the variable will still be zero, it only changes the lower bound
+of the continuous or the integer part of the variable.
+
+We need this function because Xpress has differents functions to change semi-continuous 
+or semi-integer lower bound and to change the lower bound.
+"""
+
 function _set_variable_semi_lower_bound(model, info, value)
     info.semi_lower_bound = value
     _set_variable_lower_bound(model, info, 0.0)
@@ -1126,10 +1137,7 @@ function _get_variable_lower_bound(model, info)
 end
 
 function _get_variable_semi_lower_bound(model, info)
-    if !isnan(info.semi_lower_bound)
-        return info.semi_lower_bound
-    end
-    return NaN
+    return info.semi_lower_bound
 end
 
 function _set_variable_upper_bound(model, info, value)
@@ -1315,9 +1323,7 @@ function MOI.add_constraint(
     _throw_if_existing_lower(info.bound, info.type, typeof(s), f.variable)
     _throw_if_existing_upper(info.bound, info.type, typeof(s), f.variable)
     Xpress.chgcoltype(model.inner, [info.column], Cchar['S'])
-    _set_variable_lower_bound(model, info, 0.0)
-    Xpress.chgglblimit(model.inner, [info.column], Float64[s.lower])
-    info.semi_lower_bound = s.lower
+    _set_variable_semi_lower_bound(model, info, s.lower)
     _set_variable_upper_bound(model, info, s.upper)
     info.type = SEMICONTINUOUS
     return MOI.ConstraintIndex{MOI.SingleVariable, MOI.Semicontinuous{Float64}}(f.variable.value)
@@ -1358,9 +1364,7 @@ function MOI.add_constraint(
     _throw_if_existing_lower(info.bound, info.type, typeof(s), f.variable)
     _throw_if_existing_upper(info.bound, info.type, typeof(s), f.variable)
     Xpress.chgcoltype(model.inner, [info.column], Cchar['R'])
-    _set_variable_lower_bound(model, info, 0.0)
-    info.semi_lower_bound = s.lower
-    Xpress.chgglblimit(model.inner, [info.column], Float64[s.lower])
+    _set_variable_semi_lower_bound(model, info, s.lower)
     _set_variable_upper_bound(model, info, s.upper)
     info.type = SEMIINTEGER
     return MOI.ConstraintIndex{MOI.SingleVariable, MOI.Semiinteger{Float64}}(f.variable.value)

--- a/src/MOI/MOI_wrapper.jl
+++ b/src/MOI/MOI_wrapper.jl
@@ -86,6 +86,8 @@ mutable struct VariableInfo
             "",
             NaN,
             0,
+            NaN,
+            NaN,
             NaN
         )
     end

--- a/src/api.jl
+++ b/src/api.jl
@@ -2362,7 +2362,7 @@ Used to change semi-continuous or semi-integer lower bounds, or upper limits on 
 function chgglblimit(prob::XpressProblem, _mindex::Vector{<:Integer}, _dlimit::Vector{Float64})
     ncols = length(_mindex)
     _mindex = _mindex .- 1
-    @checked Lib.XPRSchgglblimit(prob, Cint.(_mindex), _dlimit)
+    @checked Lib.XPRSchgglblimit(prob, ncols, Cint.(_mindex), _dlimit)
 end
 
 """

--- a/test/MathOptInterface/MOI_Wrapper.jl
+++ b/test/MathOptInterface/MOI_Wrapper.jl
@@ -11,6 +11,8 @@ const MOIU = MOI.Utilities
 const OPTIMIZER = Xpress.Optimizer()
 const OPTIMIZER_2 = Xpress.Optimizer()
 
+include("../SemiContInt/semicontint.jl")
+
 # Xpress can only obtain primal arrays without presolve. Check more on
 # https://www.fico.com/fico-xpress-optimization/docs/latest/solver/optimizer/HTML/XPRSgetprimalray.html
 
@@ -112,6 +114,11 @@ end
         "indicator3",
         "indicator4",
     ])
+end
+
+@testset "SemiContInt" begin
+    semiconttest(BRIDGED_OPTIMIZER, CONFIG)
+    semiinttest(BRIDGED_OPTIMIZER, CONFIG)
 end
 
 @testset "ModelLike tests" begin

--- a/test/SemiContInt/semicontint.jl
+++ b/test/SemiContInt/semicontint.jl
@@ -119,8 +119,6 @@ function semiconttest(model::MOI.ModelLike, config::MOIT.TestConfig{T}) where T
 
     MOI.set(model, MOI.ConstraintSet(), vc2, MOI.EqualTo(T(3)))
 
-    MOI.write_to_file(model.model, "antes3.lp")
-
     if config.solve
         MOI.optimize!(model)
 

--- a/test/SemiContInt/semicontint.jl
+++ b/test/SemiContInt/semicontint.jl
@@ -1,0 +1,300 @@
+function semiconttest(model::MOI.ModelLike, config::MOIT.TestConfig{T}) where T
+    atol = config.atol
+    rtol = config.rtol
+
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
+    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
+    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.MathOptInterface.Semicontinuous{T})
+
+    # 2 variables
+    # min  x
+    # st   x >= y
+    #      x ∈ {0.0} U [2.0,3.0]
+    #      y = 0.0
+
+    MOI.empty!(model)
+    @test MOI.is_empty(model)
+
+    v = MOI.add_variables(model, 2)
+    @test MOI.get(model, MOI.NumberOfVariables()) == 2
+
+    vc1 = MOI.add_constraint(model, MOI.SingleVariable(v[1]), MOI.Semicontinuous(T(2), T(3)))
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.Semicontinuous{T}}()) == 1
+
+    vc2 = MOI.add_constraint(model, MOI.SingleVariable(v[2]), MOI.EqualTo(zero(T)))
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.EqualTo{T}}()) == 1
+
+    cf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), -one(T)], v), zero(T))
+    c = MOI.add_constraint(model, cf, MOI.GreaterThan(zero(T)))
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.GreaterThan{T}}()) == 1
+
+    objf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 0.0], v), 0.0)
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+
+    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MIN_SENSE
+
+    if config.solve
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
+
+        MOI.optimize!(model)
+
+        @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
+
+        @test MOI.get(model, MOI.ResultCount()) >= 1
+
+        @test MOI.get(model, MOI.PrimalStatus()) in [ MOI.FEASIBLE_POINT, MOI.NEARLY_FEASIBLE_POINT ]
+
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [0,0] atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 0.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ObjectiveBound()) <= 0.0
+    end
+
+    # Change y fixed value
+
+    MOI.set(model, MOI.ConstraintSet(), vc2, MOI.EqualTo(one(T)))
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
+
+        @test MOI.get(model, MOI.ResultCount()) >= 1
+
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
+
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [2.0,1.0] atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 1.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ObjectiveBound()) <= 2.0
+    end
+
+    MOI.set(model, MOI.ConstraintSet(), vc2, MOI.EqualTo(T(2)))
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
+
+        @test MOI.get(model, MOI.ResultCount()) >= 1
+
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
+
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [2.0,2.0] atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 0.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ObjectiveBound()) <= 2.0
+    end
+
+    MOI.set(model, MOI.ConstraintSet(), vc2, MOI.EqualTo(T(5//2)))
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
+
+        @test MOI.get(model, MOI.ResultCount()) >= 1
+
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
+
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.5 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [2.5,2.5] atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 0.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ObjectiveBound()) <= 2.5
+    end
+
+    MOI.set(model, MOI.ConstraintSet(), vc2, MOI.EqualTo(T(3)))
+
+    MOI.write_to_file(model.model, "antes3.lp")
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
+
+        @test MOI.get(model, MOI.ResultCount()) >= 1
+
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
+
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [3.0,3.0] atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 0.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ObjectiveBound()) <= 3.0
+    end
+
+    MOI.set(model, MOI.ConstraintSet(), vc2, MOI.EqualTo(T(5)))
+
+     if config.solve
+
+        MOI.optimize!(model)
+
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE ||
+            MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE_OR_UNBOUNDED
+    end
+end
+
+function semiinttest(model::MOI.ModelLike, config::MOIT.TestConfig{T}) where T
+    atol = config.atol
+    rtol = config.rtol
+
+    @test MOIU.supports_default_copy_to(model, #=copy_names=# false)
+    @test MOI.supports(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{T}}())
+    @test MOI.supports(model, MOI.ObjectiveSense())
+    @test MOI.supports_constraint(model, MOI.SingleVariable, MOI.MathOptInterface.Semiinteger{T})
+
+    # 2 variables
+    # min  x
+    # st   x >= y
+    #      x ∈ {0.0} U {2.0} U {3.0}
+    #      y = 0.0
+
+    MOI.empty!(model)
+    @test MOI.is_empty(model)
+
+    v = MOI.add_variables(model, 2)
+    @test MOI.get(model, MOI.NumberOfVariables()) == 2
+
+    vc1 = MOI.add_constraint(model, MOI.SingleVariable(v[1]), MOI.Semiinteger(T(2), T(3)))
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.Semiinteger{T}}()) == 1
+
+    vc2 = MOI.add_constraint(model, MOI.SingleVariable(v[2]), MOI.EqualTo(zero(T)))
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.SingleVariable,MOI.EqualTo{T}}()) == 1
+
+    cf = MOI.ScalarAffineFunction{T}(MOI.ScalarAffineTerm{T}.([one(T), -one(T)], v), zero(T))
+    c = MOI.add_constraint(model, cf, MOI.GreaterThan(zero(T)))
+    @test MOI.get(model, MOI.NumberOfConstraints{MOI.ScalarAffineFunction{T},MOI.GreaterThan{T}}()) == 1
+
+    objf = MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0, 0.0], v), 0.0)
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), objf)
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+
+    @test MOI.get(model, MOI.ObjectiveSense()) == MOI.MIN_SENSE
+
+    if config.solve
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMIZE_NOT_CALLED
+
+        MOI.optimize!(model)
+
+        @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
+
+        @test MOI.get(model, MOI.ResultCount()) >= 1
+
+        @test MOI.get(model, MOI.PrimalStatus()) in [ MOI.FEASIBLE_POINT, MOI.NEARLY_FEASIBLE_POINT ]
+
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 0.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [0,0] atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 0.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ObjectiveBound()) <= 0.0
+    end
+
+    # Change y fixed value
+
+    MOI.set(model, MOI.ConstraintSet(), vc2, MOI.EqualTo(one(T)))
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
+
+        @test MOI.get(model, MOI.ResultCount()) >= 1
+
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
+
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [2.0,1.0] atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 1.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ObjectiveBound()) <= 2.0
+    end
+
+    MOI.set(model, MOI.ConstraintSet(), vc2, MOI.EqualTo(T(2)))
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
+
+        @test MOI.get(model, MOI.ResultCount()) >= 1
+
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
+
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 2.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [2.0,2.0] atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 0.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ObjectiveBound()) <= 2.0
+    end
+
+    MOI.set(model, MOI.ConstraintSet(), vc2, MOI.EqualTo(T(5//2)))
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
+
+        @test MOI.get(model, MOI.ResultCount()) >= 1
+
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
+
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [3.0,2.5] atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 0.5 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ObjectiveBound()) <= 3.0
+    end
+
+    MOI.set(model, MOI.ConstraintSet(), vc2, MOI.EqualTo(T(3)))
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.get(model, MOI.TerminationStatus()) == config.optimal_status
+
+        @test MOI.get(model, MOI.ResultCount()) >= 1
+
+        @test MOI.get(model, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
+
+        @test MOI.get(model, MOI.ObjectiveValue()) ≈ 3.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.VariablePrimal(), v) ≈ [3.0,3.0] atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ConstraintPrimal(), c) ≈ 0.0 atol=atol rtol=rtol
+
+        @test MOI.get(model, MOI.ObjectiveBound()) <= 3.0
+    end
+
+    MOI.set(model, MOI.ConstraintSet(), vc2, MOI.EqualTo(T(4)))
+
+    if config.solve
+        MOI.optimize!(model)
+
+        @test MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE ||
+            MOI.get(model, MOI.TerminationStatus()) == MOI.INFEASIBLE_OR_UNBOUNDED
+    end
+end


### PR DESCRIPTION
Solved issue #61 
The tests `SemiContInt\semicontint.jl` are not available on MOI.Test yet.