### PR TITLE
[breaking] remove incorrect set_callback_preintsol

### DIFF
--- a/src/helper.jl
+++ b/src/helper.jl
@@ -189,31 +189,3 @@ function set_callback_optnode!(
     _ = XPRSaddcboptnode(model.ptr, callback_ptr, user_data, 0)
     return callback_ptr, user_data
 end
-
-function _setcbpreintsol_wrapper(
-    ptr_model::XPRSprob,
-    ptr_user_data::Ptr{Cvoid},
-    ::Ptr{Cint},
-    ::Ptr{Cint},
-    ::Ptr{Cdouble},
-)
-    user_data = unsafe_pointer_to_objref(ptr_user_data)::_CallbackUserData
-    inner = XpressProblem(ptr_model; finalize_env = false)
-    user_data.callback(CallbackData(user_data.model, user_data.data, inner))
-    return Cint(0)
-end
-
-function set_callback_preintsol!(
-    model::XpressProblem,
-    callback::Function,
-    data::Any = nothing,
-)
-    callback_ptr = @cfunction(
-        _setcbpreintsol_wrapper,
-        Cint,
-        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cint}, Ptr{Cint}, Ptr{Cdouble})
-    )
-    user_data = _CallbackUserData(callback, model, data)
-    _ = XPRSaddcbpreintsol(model.ptr, callback_ptr, user_data, 0)
-    return callback_ptr, user_data
-end

--- a/test/test_MOI_wrapper.jl
+++ b/test/test_MOI_wrapper.jl
@@ -1305,30 +1305,32 @@ function test_callback_lazy_constraint_dual_reductions()
     return
 end
 
+function _cbpreintsol(
+    cbprob::XPRSprob,
+    cbdata::Ptr{Cdouble},
+    soltype::Cint,
+    p_reject::Ptr{Cint},
+    p_cutoff::Ptr{Cdouble},
+)
+    data = unsafe_wrap(Array, cbdata, (3, 3))
+    data[1, 1] = soltype
+    return Cint(0)
+end
+
 function test_callback_preintsol()
     model, x, y = callback_simple_model()
-    data = [1.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 1.0]
-    function foo(cb::Xpress.CallbackData)
-        cb.data[1] = 98
-        pInt = Ref{Cint}(0)
-        XPRSgetintattrib(cb.model, XPRS_COLS, pInt)
-        cols = pInt[]
-        ans_variable_primal = Vector{Float64}(undef, cols)
-        ans_linear_primal = Vector{Float64}(undef, cols)
-        XPRSgetlpsol(
-            cb.model,
-            ans_variable_primal,
-            ans_linear_primal,
-            C_NULL,
-            C_NULL,
-        )
-        return
+    callback_ptr = @cfunction(
+        _cbpreintsol,
+        Cint,
+        (XPRSprob, Ptr{Cdouble}, Cint, Ptr{Cint}, Ptr{Cdouble})
+    )
+    data = Cint[-1 0 0; 0 1 0; 0 0 1]
+    GC.@preserve data begin
+        _ = XPRSaddcbpreintsol(model, callback_ptr, data, 0)
+        @test data[1] == -1
+        MOI.optimize!(model)
+        @test data[1] in (0, 1)  # Either continuous relaxation or heuristic
     end
-    func_ptr, data_ptr = Xpress.set_callback_preintsol!(model.inner, foo, data)
-    @test data[1] == 1
-    MOI.optimize!(model)
-    @test data[1] == 98
-    @test func_ptr isa Ptr{Cvoid}
     return
 end
 


### PR DESCRIPTION
This callback was a bit useless without access to `soltype`, `p_reject`, and `p_cutoff`, and also the signature wasn't correct. It should have been `soltype::Cint` instead of soltype::Ptr{Cint}`, so anyone taking inspiration from this function was in for trouble.

Also the test ran the risk of segfaulting because it didn't GC preserve the `_CallbackUserData`.

The philosophy now is to make it possible to write the callbacks using the C API, but not to provide convenience wrappers that expose only half the functionality.