### PR TITLE
Prep for v0.18.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Xpress"
 uuid = "9e70acf3-d6c9-5be6-b5bd-4e2c73e3e054"
-version = "0.17.2"
+version = "0.18.0"
 authors = ["Joaquim Dias Garcia <joaquim@psr-inc.com>, Dheepak Krishnamurthy <me@kdheepak.com>, Jose Daniel Lara <jdlara@berkeley.edu>"]
 url = "https://github.com/jump-dev/Xpress.jl"
 


### PR DESCRIPTION
Since it is such a large breaking release, I wrote some proper release notes.

# Release notes v0.18.0

This is a large breaking release. The purpose of this release was to clean up a
lot of the wrapper by removing the intermediate API between MathOptInterface and
C.

These changes are motivated by our experience maintaining other solver wrappers:
the fewer layers of indirection between MOI and the solver the better, even if
the code is more verbose. In particular, macros seem like they make things
easier to read, but they distract from the code that actually runs. And helper
functions that automate some of the handling of C arguments like `Ref{Cint}`
obscure the underlying C calls.

## Breaking

- Support for Xpress v8 and earlier has been removed. There are no work-arounds.
  The only supported versions are minor and patch releases in the Xpress v9
  series.

- Droped support for Julia@1.6 and make minimum v1.10 (#297)

  This change is technically not breaking because users on v1.6 will not be able
  to upgrade to this version, but it is worth advertising.
 
- [breaking] simplify the wrapper by removing the intermediate API (#298)

  This PR is breaking for any code that touched the `Xpress.Lib` submodule, any
  code in `src/api.jl`, or any code that used `@_invoke` or `@checked`.

  There are no simple work-arounds. Instead, you must rewrite your code to use
  the underlying C API directly.

  As an example, instead of
  ```julia
  using Xpress
  prob = Xpress.XpressProblem()
  value = Xpress.getintcontrol(prob, Xpress.XPRS_OUTPUTFLAG)
  ```
  do
  ```julia
  using Xpress
  prob = Xpress.XpressProblem()
  pInt = Ref{Cint}(0)
  ret = XPRSgetintcontrol(prob, XPRS_OUTPUTFLAG, pInt)
  @assert ret == 0  # Check error code
  value = pInt[]
  ```
  If you need help updating your code, please open a GitHub isssue and tag
  `@odow`.

- [breaking] remove kwargs from Optimizer constructor (#300)

  This PR removed the ability to set options via `Xpress.Optimizer(; kwargs...)`.
  Use `JuMP.set_attribute` or `MOI.RawOptimizerAttribute` instead. We made this
  change to align with the rest of the JuMP ecosystem.

- [breaking] remove incorrect set_callback_preintsol (#309)

  This PR removed `Xpress.set_callback_preintsol`. You can still set this
  callback manually using `XPRSaddcbpreintsol`. We removed this function because
  it wasn't used by the MOI wrapper, and it did not expose the full capabilities
  of the underlying callback.

- [breaking] remove set_callback_optnode! (#310)

  This PR removed `Xpress.set_callback_optnode!`. You can still set this
  callback manually using `XPRSaddcboptnode`, or by setting the
  `Xpress.CallbackFunction` attribute. We removed this function because
  it could equivalently be called by `CallbackFunction`, and it did not expose
  the full capabilities of the underlying callback.

- [breaking] move logfile field from XpressProblem to Optimizer (#312)

  The `XpressProblem(; logfile)` keyword argument has been removed. If you are
  using the C API, call `XPRSsetlogfile` instead. If you are using the MOI
  wrapper, set the `"logfile"` attribute.

## Added

- Add support for CTRL+C during the solve (#307)

  This PR adds support for interrupting the solver during `optimize!`. It
  applies only to MIP models.

 - Add support for ScalarQuadraticFunction-in-EqualTo (#319)

  Previously this was supported by a bridge adding two constraints: `f(x) <= a` and `f(x) >= a`. 

## Fixed

- Switch to XPRSoptimize and remove lp/mip/nlp switches (#299)

  As a result of this PR, Xpress will now automatically detect the problem type
  and use the appropriate solver. This fixes a bug in which non-convex quadratic
  programs were not supported by the MOI wrapper.

## Other

- Update versions in GitHub actions (#296)
- Add a CI job to test local installation (#301)
- Remove unnecessary XPRSloadlp (#303)
- Write the filename of libxprs to deps.jl instead of the directory (#302)
- Remove kwargs from Optimizer in tests (#304)
- Test Xpress_jll@9.8.1 in CI (#306)
- Clean up and tidy the test/test_MOI_wrapper.jl file (#305)
- Move message callback into MOI wrapper (#308)
- Remove the separate helper.jl and license.jl files (#311)
- Set XPRS_CALLBACKFROMMAINTHREAD when adding a callback (#314)
- Remove unused solve_relaxation (#315)
- Remove setting MPSNAMELENGTH by default (#316) 
- Minor formatting changes for the MOI wrapper (#318)