### PR TITLE
Set HEUREMPHASIS automatically for MOI callbacks

### DIFF
--- a/src/MOI/MOI_wrapper.jl
+++ b/src/MOI/MOI_wrapper.jl
@@ -3087,14 +3087,10 @@ end
 function MOI.optimize!(model::Optimizer)
     # Initialize callbacks if necessary.
     if check_moi_callback_validity(model)
-        pInt = Ref{Cint}()
-        ret = XPRSgetintcontrol(model, XPRS_HEURSTRATEGY, pInt)
+        # Disable heuristics. There numerous cases where the heuristics ignore
+        # our callbacks.
+        ret = XPRSsetintcontrol(model, XPRS_HEUREMPHASIS, 0)
         _check(model, ret)
-        if model.moi_warnings && pInt[] != 0
-            @warn(
-                "Callbacks in XPRESS might not work correctly with HEURSTRATEGY != 0",
-            )
-        end
         MOI.set(model, CallbackFunction(), default_moi_callback(model))
         model.has_generic_callback = false # because it is set as true in the above
     elseif !model.has_generic_callback && is_mip(model)

--- a/test/test_MOI_wrapper.jl
+++ b/test/test_MOI_wrapper.jl
@@ -843,8 +843,6 @@ end
 function callback_simple_model()
     model = Xpress.Optimizer()
     MOI.set(model, MOI.RawOptimizerAttribute("OUTPUTLOG"), 0)
-    MOI.set(model, MOI.RawOptimizerAttribute("HEURSTRATEGY"), 0)
-    MOI.set(model, MOI.RawOptimizerAttribute("HEUREMPHASIS"), 0)
     MOI.set(model, MOI.RawOptimizerAttribute("CUTSTRATEGY"), 0)
     MOI.set(model, MOI.RawOptimizerAttribute("PRESOLVE"), 0)
     MOI.Utilities.loadfromstring!(
@@ -866,7 +864,6 @@ end
 function callback_knapsack_model()
     model = Xpress.Optimizer()
     MOI.set(model, MOI.RawOptimizerAttribute("OUTPUTLOG"), 0)
-    MOI.set(model, MOI.RawOptimizerAttribute("HEUREMPHASIS"), 0)
     MOI.set(model, MOI.RawOptimizerAttribute("CUTSTRATEGY"), 0)
     MOI.set(model, MOI.RawOptimizerAttribute("PRESOLVE"), 0)
     MOI.set(model, MOI.NumberOfThreads(), 2)


### PR DESCRIPTION
Why do we warn when we could just set this automatically. We set other attributes like `MIPDUALREDUCTIONS` for the cut callbacks.